### PR TITLE
Add fallthrough attribute

### DIFF
--- a/components/standing_desk_height/omnidesk_decoder.cpp
+++ b/components/standing_desk_height/omnidesk_decoder.cpp
@@ -11,6 +11,7 @@ bool OmnideskDecoder::put(uint8_t b) {
       state_ = HEIGHT2;
       return false;
     }
+    [[fallthrough]];
   default:
     return UpliftDecoder::put(b);
   }


### PR DESCRIPTION
Fixes the following compilation warning:

```
src/esphome/components/standing_desk_height/omnidesk_decoder.cpp: In member function 'virtual bool esphome::standing_desk_height::OmnideskDecoder::put(uint8_t)':
src/esphome/components/standing_desk_height/omnidesk_decoder.cpp:9:5: warning: this statement may fall through [-Wimplicit-fallthrough=]
     if (b == 0x02 || b == 0x03 || b == 0x04) {
     ^~
src/esphome/components/standing_desk_height/omnidesk_decoder.cpp:14:3: note: here
   default:
   ^~~~~~~
```